### PR TITLE
Update readme with all auto-collect setters

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ appInsights.setup("<instrumentation_key>")
     .setAutoCollectRequests(false)
     .setAutoCollectPerformance(false)
     .setAutoCollectExceptions(false)
+    .setAutoCollectDependencies(false)
     // no telemetry will be sent until .start() is called
     .start();
 ```


### PR DESCRIPTION
Add `setAutoCollectDependencies(false)` to section "Disabling auto-collection".

In my case a sloppy usage based on looking at just the readme led to [#184](https://github.com/Microsoft/ApplicationInsights-node.js/issues/184)